### PR TITLE
Improve token error handling

### DIFF
--- a/01-frontend/app/knowledge-base/page.tsx
+++ b/01-frontend/app/knowledge-base/page.tsx
@@ -28,6 +28,7 @@ import {
   RefreshCw,
 } from "lucide-react"; // Example icons
 import { useSession } from "next-auth/react"; // Import useSession
+import { authFetch } from "@/lib/authFetch";
 
 // Define a type for knowledge items (replace with your actual data structure)
 type KnowledgeItem = {
@@ -87,17 +88,9 @@ export default function KnowledgeBasePage() {
     }
 
     try {
-      const response = await fetch(GET_ITEMS_ENDPOINT, {
-        headers: {
-          Authorization: `Bearer ${session.idToken}`,
-        },
-      });
+      const response = await authFetch(session, GET_ITEMS_ENDPOINT);
       if (!response.ok) {
-         if (response.status === 401 || response.status === 403) {
-            console.error("Unauthorized. Token might be invalid or expired.");
-            // Optionally trigger sign out or refresh
-            // signOut();
-         } else {
+         if (response.status !== 401 && response.status !== 403) {
             throw new Error(`Failed to fetch items: ${response.statusText}`);
          }
          // If unauthorized, clear items and stop
@@ -484,11 +477,8 @@ export default function KnowledgeBasePage() {
           return;
         }
 
-        const response = await fetch(`${DELETE_ITEM_ENDPOINT}/${id}`, { // Append ID to URL
+        const response = await authFetch(session, `${DELETE_ITEM_ENDPOINT}/${id}`, {
           method: "DELETE",
-          headers: {
-              'Authorization': `Bearer ${session.idToken}`,
-          }
         });
 
         // Handle Backend Response

--- a/01-frontend/app/page.tsx
+++ b/01-frontend/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useSession, signIn } from "next-auth/react";
+import { authFetch } from "@/lib/authFetch";
 import { Button } from "@/components/ui/button";
 import { Loader2 } from "lucide-react";
 import { useState, useEffect, useCallback } from "react";
@@ -102,17 +103,15 @@ export default function HomePage() {
 
     setIsLoading(true);
     try {
-      const response = await fetch('/api/documents', {
-        headers: {
-          Authorization: `Bearer ${session.idToken}`,
-        },
-      });
+      const response = await authFetch(session, '/api/documents');
 
       if (response.ok) {
         const data: Document[] = await response.json();
-        setDocuments(data.filter(doc => doc.status === 'Ready')); // Only show ready documents
+        setDocuments(data.filter(doc => doc.status === 'Ready'));
       } else {
-        console.error('Failed to fetch documents:', response.statusText);
+        if (response.status !== 401 && response.status !== 403) {
+          console.error('Failed to fetch documents:', response.statusText);
+        }
       }
     } catch (error) {
       console.error('Error fetching documents:', error);

--- a/01-frontend/lib/authFetch.ts
+++ b/01-frontend/lib/authFetch.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { signOut } from 'next-auth/react';
+
+export async function authFetch(
+  session: { idToken?: string } | null | undefined,
+  input: RequestInfo,
+  init: RequestInit = {}
+) {
+  if (!session?.idToken) {
+    throw new Error('Missing authentication token');
+  }
+
+  const resp = await fetch(input, {
+    ...init,
+    headers: {
+      ...(init.headers || {}),
+      Authorization: `Bearer ${session.idToken}`,
+    },
+  });
+
+  if (resp.status === 401 || resp.status === 403) {
+    console.error('Authentication failed, signing out');
+    signOut();
+  }
+
+  return resp;
+}

--- a/02-backend/app/api/auth.py
+++ b/02-backend/app/api/auth.py
@@ -61,9 +61,14 @@ async def verify_token(
     except ValueError as e:
         # This catches invalid token format, signature, expiry, audience mismatch, etc.
         logging.error(f"Token verification failed: {e}", exc_info=True)
+        message = str(e)
+        if "Token expired" in message:
+            detail = "Token expired. Please sign in again."
+        else:
+            detail = f"Invalid authentication credentials: {message}"
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=f"Invalid authentication credentials: {e}",
+            detail=detail,
             headers={"WWW-Authenticate": "Bearer"},
         )
     except Exception as e:


### PR DESCRIPTION
## Summary
- add `authFetch` utility for authenticated requests that signs users out on 401/403
- use `authFetch` in knowledge base and home pages
- provide clearer expired-token messages in backend auth

## Testing
- `npm --prefix 01-frontend run lint` *(fails: next not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*
