### PR TITLE
Add local running support for processing service

### DIFF
--- a/03-processing/main.py
+++ b/03-processing/main.py
@@ -14,7 +14,7 @@ import tiktoken
 import uvicorn
 from fastapi import FastAPI, HTTPException, Request
 from google.cloud import storage
-from google.cloud.sql.connector import Connector
+from google.cloud.sql.connector import Connector, IPTypes
 from pydantic import BaseModel
 
 import vertexai
@@ -41,6 +41,8 @@ INSTANCE_CONNECTION_NAME: str = os.environ["CLOUD_SQL_INSTANCE"]
 DB_USER: str = os.environ["CLOUD_SQL_USER"]
 DB_PASS: str = os.environ["CLOUD_SQL_PASSWORD"]
 DB_NAME: str = os.environ["CLOUD_SQL_DB"]
+IP_TYPE_ENV: str = os.environ.get("CLOUD_SQL_IP_TYPE", "PRIVATE").upper()
+IP_TYPE = IPTypes.PRIVATE if IP_TYPE_ENV == "PRIVATE" else IPTypes.PUBLIC
 EMBED_MODEL: str = os.environ["EMBED_MODEL"]
 GEMINI_MODEL: str = os.environ["GEMINI_MODEL"]
 
@@ -109,7 +111,7 @@ def _connect() -> Iterator["pg8000.Connection"]:
         user=DB_USER,
         password=DB_PASS,
         db=DB_NAME,
-        ip_type="PRIVATE",
+        ip_type=IP_TYPE,
     )
     try:
         yield conn

--- a/03-processing/scraper.py
+++ b/03-processing/scraper.py
@@ -16,7 +16,7 @@ import umap
 
 import vertexai
 from vertexai.language_models import TextEmbeddingModel
-from google.cloud.sql.connector import Connector
+from google.cloud.sql.connector import Connector, IPTypes
 from dotenv import load_dotenv
 
 # Load environment variables from .env file
@@ -29,6 +29,8 @@ INSTANCE_CONNECTION_NAME = os.environ.get("CLOUD_SQL_INSTANCE", "test:instance")
 DB_USER = os.environ.get("CLOUD_SQL_USER", "test-user")
 DB_PASS = os.environ.get("CLOUD_SQL_PASSWORD", "test-pass")
 DB_NAME = os.environ.get("CLOUD_SQL_DB", "test-db")
+IP_TYPE_ENV = os.environ.get("CLOUD_SQL_IP_TYPE", "PRIVATE").upper()
+IP_TYPE = IPTypes.PRIVATE if IP_TYPE_ENV == "PRIVATE" else IPTypes.PUBLIC
 EMBED_MODEL = os.environ.get("EMBED_MODEL", "text-embedding-004")
 
 # Configure logging
@@ -77,7 +79,7 @@ class WebDocumentProcessor:
                 user=DB_USER,
                 password=DB_PASS,
                 db=DB_NAME,
-                ip_type="PRIVATE",
+                ip_type=IP_TYPE,
             )
             logger.info("✅ Database connection established")
             yield conn

--- a/README_3D_IMPLEMENTATION.md
+++ b/README_3D_IMPLEMENTATION.md
@@ -47,6 +47,8 @@ CLOUD_SQL_INSTANCE=your-instance-connection-name
 CLOUD_SQL_USER=your-db-user
 CLOUD_SQL_PASSWORD=your-db-password
 CLOUD_SQL_DB=docs
+# When running locally use the instance's public IP
+CLOUD_SQL_IP_TYPE=PUBLIC
 EMBED_MODEL=text-embedding-004
 PROCESSING_SERVICE_URL=http://localhost:8080  # For backend config
 ```

--- a/start.sh
+++ b/start.sh
@@ -2,6 +2,12 @@
 
 echo "🚀 Starting Support Flow..."
 
+# Start processing service in background
+echo "Starting processing service..."
+cd 03-processing
+uvicorn main:app --reload --port 8080 &
+cd ..
+
 # Start backend in background
 echo "Starting backend..."
 cd 02-backend


### PR DESCRIPTION
## Summary
- allow setting `CLOUD_SQL_IP_TYPE` for processing service
- show how to set `CLOUD_SQL_IP_TYPE` in README
- start the processing service in `start.sh` for local dev

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*