### PR TITLE
Add collapsible chat sidebar on landing page

### DIFF
--- a/01-frontend/app/page.tsx
+++ b/01-frontend/app/page.tsx
@@ -5,7 +5,7 @@ import { authFetch } from "@/lib/authFetch";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Loader2 } from "lucide-react";
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import {
   Dialog,
   DialogContent,
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/dialog";
 import { format } from "date-fns";
 import DocumentCloud3D from "@/components/DocumentCloud3D";
+import ChatSidebar, { ChatSidebarHandle } from "@/components/ChatSidebar";
 
 // Document interface matching the knowledge base
 interface Document {
@@ -92,6 +93,7 @@ export default function HomePage() {
   ]);
   const [agentInstruction, setAgentInstruction] = useState('');
   const [activeAgentId, setActiveAgentId] = useState('maxi');
+  const chatSidebarRef = useRef<ChatSidebarHandle>(null);
 
   // Fetch documents from the knowledge base
   const fetchDocuments = useCallback(async () => {
@@ -168,6 +170,9 @@ export default function HomePage() {
 
     // Start the movement sequence
     moveAgentThroughWaypoints(agentId, waypoints);
+
+    // Send the instruction to the chat sidebar
+    chatSidebarRef.current?.sendMessage(agentInstruction.trim());
 
     // Clear input after sending
     setAgentInstruction('');
@@ -343,6 +348,7 @@ export default function HomePage() {
           )}
         </DialogContent>
       </Dialog>
+      <ChatSidebar ref={chatSidebarRef} />
     </div>
   );
 }

--- a/01-frontend/components/ChatSidebar.tsx
+++ b/01-frontend/components/ChatSidebar.tsx
@@ -1,0 +1,104 @@
+import React, { forwardRef, useImperativeHandle, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { ScrollArea } from '@/components/ui/scroll-area';
+
+export interface ChatSidebarHandle {
+  sendMessage: (text: string) => void;
+}
+
+type Message = { id: string; text: string; sender: 'user' | 'bot' };
+
+const ChatSidebar = forwardRef<ChatSidebarHandle>((_, ref) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [chatId, setChatId] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const sendMessage = async (text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+
+    const optimistic: Message = {
+      id: `temp-${Date.now()}`,
+      text: trimmed,
+      sender: 'user',
+    };
+
+    setMessages((prev) => [...prev, optimistic]);
+    setIsOpen(true);
+    setIsLoading(true);
+
+    let currentChatId = chatId;
+    try {
+      if (!currentChatId) {
+        const res = await fetch('/api/chats', { method: 'POST' });
+        if (!res.ok) throw new Error('Failed to create chat');
+        const data = await res.json();
+        currentChatId = data.id;
+        setChatId(currentChatId);
+      }
+
+      const res = await fetch(`/api/chats/${currentChatId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query: trimmed }),
+      });
+      if (!res.ok) throw new Error('Failed to send message');
+      const { user_message, bot_message } = await res.json();
+
+      setMessages((prev) => [
+        ...prev.filter((m) => m.id !== optimistic.id),
+        user_message,
+        bot_message,
+      ]);
+    } catch (err) {
+      console.error('Error sending message:', err);
+      setMessages((prev) => [
+        ...prev.filter((m) => m.id !== optimistic.id),
+        { id: `err-${Date.now()}`, text: 'Error getting reply', sender: 'bot' },
+      ]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useImperativeHandle(ref, () => ({ sendMessage }));
+
+  return (
+    <>
+      <div
+        className={`fixed top-14 right-0 h-[calc(100vh-theme(spacing.14))] w-80 bg-background border-l shadow-lg transition-transform ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}
+      >
+        <ScrollArea className="h-full p-4 space-y-2">
+          {messages.map((m) => (
+            <div
+              key={m.id}
+              className={`text-sm ${m.sender === 'user' ? 'text-right' : 'text-left'}`}
+            >
+              <div
+                className={`inline-block px-3 py-2 rounded-lg ${m.sender === 'user' ? 'bg-primary text-primary-foreground' : 'bg-muted'}`}
+              >
+                {m.text}
+              </div>
+            </div>
+          ))}
+          {isLoading && (
+            <div className="flex items-center space-x-2 text-sm text-muted-foreground">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              <span>Thinking...</span>
+            </div>
+          )}
+        </ScrollArea>
+      </div>
+      <button
+        onClick={() => setIsOpen((o) => !o)}
+        className="fixed top-1/2 right-0 transform -translate-y-1/2 translate-x-full bg-muted border-l rounded-l px-2 py-1 text-sm shadow"
+      >
+        {isOpen ? '➤' : '◀'}
+      </button>
+    </>
+  );
+});
+
+ChatSidebar.displayName = 'ChatSidebar';
+export default ChatSidebar;


### PR DESCRIPTION
## Summary
- add new `ChatSidebar` component
- hook landing page input to sidebar and open chat when a query is sent

## Testing
- `npm run lint` *(fails: Unexpected any)*