### PR TITLE
Implement public DB connection context manager

### DIFF
--- a/02-backend/app/services/cloudsql.py
+++ b/02-backend/app/services/cloudsql.py
@@ -47,6 +47,12 @@ class CloudSqlRepository:
             if conn:
                 conn.close()
                 logging.debug("Cloud SQL connection closed.")
+
+    @contextmanager
+    def get_connection(self) -> Iterator[Any]:
+        """Public wrapper around ``_get_conn`` for external callers."""
+        with self._get_conn() as conn:
+            yield conn
                 
     def _to_pgvector(self, vec: List[float]) -> str:
         # keep it dense → smaller payload, less parsing time

--- a/02-backend/app/services/pocketflow_service.py
+++ b/02-backend/app/services/pocketflow_service.py
@@ -32,6 +32,7 @@ class PocketFlowService:
     def _get_db_connection(self):
         """Get database connection for PocketFlow operations."""
         try:
+            # Use the public connection context manager from CloudSqlRepository
             with self.sql_repo.get_connection() as conn:
                 yield conn
         except Exception as e:


### PR DESCRIPTION
## Summary
- expose a `get_connection` context manager in `cloudsql.py`
- ensure `PocketFlowService` uses this new helper

## Testing
- `python -m py_compile 02-backend/app/services/cloudsql.py 02-backend/app/services/pocketflow_service.py`

------
https://chatgpt.com/codex/tasks/task_e_683b5de1cc80832ab60be1e221cd055e