### PR TITLE
Set chat as default landing page

### DIFF
--- a/01-frontend/app/page.tsx
+++ b/01-frontend/app/page.tsx
@@ -3,9 +3,18 @@
 import { useSession, signIn } from "next-auth/react";
 import { Button } from "@/components/ui/button";
 import { Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
 export default function HomePage() {
-  const { data: session, status } = useSession();
+  const { status } = useSession();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (status === "authenticated") {
+      router.replace("/chat");
+    }
+  }, [status, router]);
 
   if (status === "loading") {
     return (
@@ -19,15 +28,16 @@ export default function HomePage() {
     return (
       <div className="flex flex-col items-center justify-center h-full">
         <p className="text-lg mb-4">Please sign in to continue.</p>
-        <Button onClick={() => signIn("google")}>Sign In with Google</Button>
+        <Button onClick={() => signIn("google", { callbackUrl: "/chat" })}>
+          Sign In with Google
+        </Button>
       </div>
     );
   }
 
   return (
-    <div className="flex flex-col items-center justify-center h-full">
-      <h1 className="text-3xl font-bold">Welcome to bloomlake</h1>
-      <p className="text-muted-foreground">This is your dashboard.</p>
+    <div className="flex items-center justify-center h-full">
+      <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
     </div>
   );
 }

--- a/01-frontend/components/main-nav.tsx
+++ b/01-frontend/components/main-nav.tsx
@@ -25,7 +25,7 @@ export function MainNav({
   return (
     <div className={cn("flex w-full items-center justify-between", className)} {...props}>
       <div className="flex items-center space-x-6">
-        <Link href="/" className="mr-6 flex items-center space-x-2">
+        <Link href="/chat" className="mr-6 flex items-center space-x-2">
           <span className="font-bold sm:inline-block">
             bloomlake
           </span>
@@ -34,7 +34,7 @@ export function MainNav({
           <NavigationMenuList>
             <NavigationMenuItem>
               <NavigationMenuLink asChild>
-                <Link href="/" className={navigationMenuTriggerStyle()}>
+                <Link href="/chat" className={navigationMenuTriggerStyle()}>
                   Home
                 </Link>
               </NavigationMenuLink>
@@ -70,7 +70,11 @@ export function MainNav({
             </Button>
           </>
         ) : (
-          <Button variant="default" size="sm" onClick={() => signIn("google")}>
+          <Button
+            variant="default"
+            size="sm"
+            onClick={() => signIn("google", { callbackUrl: "/chat" })}
+          >
             <LogIn className="mr-2 h-4 w-4" /> Sign In
           </Button>
         )}


### PR DESCRIPTION
## Summary
- make home redirect to chat
- update navigation to link home to chat
- redirect login to chat after signing in

## Testing
- `npm run lint` *(fails: Unexpected any, unused variables, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6843fa98181c832aa1f1b5bfe04172a3